### PR TITLE
Avoid superfluous empty line after clearing buffer

### DIFF
--- a/lib/autoreporter.rb
+++ b/lib/autoreporter.rb
@@ -24,7 +24,7 @@ class Autoreporter
 
   def clear_terminal!
     # system("clear") doesn't clear scrollback buffer on iTerm2, we need to do this:
-    puts "\e[H\e[J\e[3J"
+    print "\e[H\e[J\e[3J"
   end
 
   def display_result!


### PR DESCRIPTION
Using `puts` outputs the ANSI sequence to clear the terminal/screen buffer, followed by `$\`, which then introduces a superfluous empty line at the top of the screen... using `print` will output just the ANSI sequence, but not the extra line _(due to not outputting the output field separator)_.
